### PR TITLE
Rename clang-format to dvlt-format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,7 @@ endif()
 # one for llvm+clang+... using the same sources.
 set(LLVM_ALL_PROJECTS "clang;libcxx;libcxxabi;lldb;compiler-rt;lld;polly")
 set(LLVM_ENABLE_PROJECTS "" CACHE STRING
-	"Semicolon-separated list of projects to build (${LLVM_ALL_PROJECTS}), or \"all\".")
+       "Semicolon-separated list of projects to build (${LLVM_ALL_PROJECTS}), or \"all\".")
 if( LLVM_ENABLE_PROJECTS STREQUAL "all" )
   set( LLVM_ENABLE_PROJECTS ${LLVM_ALL_PROJECTS})
 endif()
@@ -986,4 +986,5 @@ endif()
 install(
   PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/bin/clang-format
   DESTINATION bin
+  RENAME dvlt-format
   COMPONENT app)


### PR DESCRIPTION
As we plan to make some modifications on our side, we prefer renaming
clang-format to dvlt-format